### PR TITLE
Support multiple display formatting options for RSS feeds.

### DIFF
--- a/app/controllers/rss_feeds_controller.rb
+++ b/app/controllers/rss_feeds_controller.rb
@@ -7,7 +7,7 @@ class RssFeedsController < ApplicationController
 
   # GET /rss_feeds/new
   def new
-    @rss_feed = RssFeed.new
+    @rss_feed = RssFeed.new(formatter: :headlines)
   end
 
   # GET /rss_feeds/1/edit
@@ -65,6 +65,6 @@ class RssFeedsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def rss_feed_params
-      params.require(:rss_feed).permit(:name, :description, :url)
+      params.require(:rss_feed).permit(:name, :description, :url, :formatter)
     end
 end

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -71,12 +71,13 @@ class RssFeed < Feed
 
         if details?
           items.each do |item|
-            contents << "<h1>#{item[:title]}</h1><p>#{item[:description]}</p>"
+            description = ActionController::Base.helpers.sanitize(item[:description])
+            contents << "<h1>#{CGI.escapeHTML(item[:title])}</h1><p>#{description}</p>"
           end
         else # headlines
           items.each_slice(5).with_index do |slice, index|
-            item_titles = slice.map { |i| i[:title] }
-            contents << "<h1>#{title}</h1><h2>#{item_titles.join("</h2><h2>")}</h2>"
+            item_titles = slice.map { |i| CGI.escapeHTML(i[:title]) }
+            contents << "<h1>#{CGI.escapeHTML(title)}</h1><h2>#{item_titles.join("</h2><h2>")}</h2>"
           end
         end
 

--- a/app/models/rss_feed.rb
+++ b/app/models/rss_feed.rb
@@ -1,7 +1,7 @@
 require "open-uri"
 
 class RssFeed < Feed
-    store_accessor :config, [ :url, :last_refreshed, :refresh_interval ]
+    store_accessor :config, [ :url, :last_refreshed, :refresh_interval, :formatter ]
 
     def last_refreshed
       DateTime.parse(super) if super
@@ -9,6 +9,12 @@ class RssFeed < Feed
 
     def refresh_interval
       super.to_i if super
+    end
+
+    def headlines? = formatter == "headlines"
+    def details? = formatter == "details"
+    def self.formatters
+      { headlines: "headlines", details: "details" }
     end
 
     def refresh
@@ -57,14 +63,21 @@ class RssFeed < Feed
 
         title = doc.xpath("/rss/channel/title").text
         items = doc.xpath("//item").map do |item|
-          item.xpath("title").text
+          { title: item.xpath("title").text,
+            description: item.xpath("description").text }
         end
 
         contents = []
 
-        items.each_slice(5).with_index do |slice, index|
-          text = "<h1>#{title}</h1><h2>#{slice.join("</h2><h2>")}</h2>"
-          contents.push(text)
+        if details?
+          items.each do |item|
+            contents << "<h1>#{item[:title]}</h1><p>#{item[:description]}</p>"
+          end
+        else # headlines
+          items.each_slice(5).with_index do |slice, index|
+            item_titles = slice.map { |i| i[:title] }
+            contents << "<h1>#{title}</h1><h2>#{item_titles.join("</h2><h2>")}</h2>"
+          end
         end
 
         contents

--- a/app/views/rss_feeds/_form.html.erb
+++ b/app/views/rss_feeds/_form.html.erb
@@ -26,6 +26,11 @@
     <%= form.text_field :url, class: "frm-input" %>
   </div>
 
+  <div class="sm:col-span-full">
+    <%= form.label :formatter, "Dispay Type", class: "frm-label" %>
+    <%= form.select :formatter, RssFeed.formatters.keys, {}, { class: "frm-input" } %>
+  </div>
+
   <div class="mt-8">
     <%= form.submit class: "btn" %>
   </div>

--- a/app/views/rss_feeds/_form.html.erb
+++ b/app/views/rss_feeds/_form.html.erb
@@ -27,7 +27,7 @@
   </div>
 
   <div class="sm:col-span-full">
-    <%= form.label :formatter, "Dispay Type", class: "frm-label" %>
+    <%= form.label :formatter, "Display Type", class: "frm-label" %>
     <%= form.select :formatter, RssFeed.formatters.keys, {}, { class: "frm-input" } %>
   </div>
 

--- a/test/controllers/rss_feeds_controller_test.rb
+++ b/test/controllers/rss_feeds_controller_test.rb
@@ -12,7 +12,8 @@ class RssFeedsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create rss_feed" do
     assert_difference("RssFeed.count") do
-      post rss_feeds_url, params: { rss_feed: { description: @rss_feed.description, name: @rss_feed.name, url: @rss_feed.url } }
+      post rss_feeds_url, params: { rss_feed: { description: @rss_feed.description, name: @rss_feed.name, url: @rss_feed.url,
+        formatter: @rss_feed.formatter } }
     end
 
     assert_redirected_to rss_feed_url(RssFeed.last)
@@ -29,7 +30,8 @@ class RssFeedsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update rss_feed" do
-    patch rss_feed_url(@rss_feed), params: { rss_feed: { description: @rss_feed.description, name: @rss_feed.name, url: @rss_feed.url } }
+    patch rss_feed_url(@rss_feed), params: { rss_feed: { description: @rss_feed.description, name: @rss_feed.name, url: @rss_feed.url,
+      formatter: @rss_feed.formatter } }
     assert_redirected_to rss_feed_url(@rss_feed)
   end
 

--- a/test/fixtures/rss_feeds.yml
+++ b/test/fixtures/rss_feeds.yml
@@ -4,10 +4,10 @@ yahoo_rssfeed:
   type: RssFeed
   name: Yahoo News RSS
   description: MyText
-  config: {'url': 'https://news.yahoo.com/rss/us'}
+  config: {'url': 'https://news.yahoo.com/rss/us', 'formatter': 'headlines'}
 
 nytimes_rssfeed:
   type: RssFeed
   name: NYTimes RSS
   description: MyText
-  config: {'url': 'https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml'}
+  config: {'url': 'https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml', 'formatter': 'details'}

--- a/test/models/rss_feed_test.rb
+++ b/test/models/rss_feed_test.rb
@@ -19,7 +19,7 @@ class RssFeedTest < ActiveSupport::TestCase
       assert_equal items[0], [
         "<h1>Yahoo News - Latest News &amp; Headlines</h1>",
         "<h2>Item 1 Title</h2>",
-        "<h2>Item 2 Title</h2>",
+        "<h2>Item 2 Title &amp; is fancy</h2>",
         "<h2>Item 3 Title</h2>",
         "<h2>Item 4 Title</h2>",
         "<h2>Item 5 Title</h2>" ].join()
@@ -95,8 +95,8 @@ class RssFeedTest < ActiveSupport::TestCase
       ].join()
 
       assert_equal items[1], [
-        "<h1>Item 2 Title</h1>",
-        "<p>Description for Item 2</p>"
+        "<h1>Item 2 Title &amp; is fancy</h1>",
+        "<p>Description for Item 2 &amp; too!</p>"
       ].join()
     end
     mock.verify

--- a/test/models/rss_feed_test.rb
+++ b/test/models/rss_feed_test.rb
@@ -77,4 +77,28 @@ class RssFeedTest < ActiveSupport::TestCase
     assert_empty content[1].text
     assert_operator content[1].end_time, :<, Time.now
   end
+
+  test "parses details from a simple RSS feed" do
+    @feed.formatter = "details"
+    mock_file = File.read("test/support/basic_rss_feed.xml")
+
+    mock = Minitest::Mock.new
+    mock.expect(:open, mock_file)
+
+    URI.stub(:parse, mock) do
+      items = @feed.new_items
+      assert_equal items.length, 10
+
+      assert_equal items[0], [
+        "<h1>Item 1 Title</h1>",
+        "<p>Description for Item 1</p>"
+      ].join()
+
+      assert_equal items[1], [
+        "<h1>Item 2 Title</h1>",
+        "<p>Description for Item 2</p>"
+      ].join()
+    end
+    mock.verify
+  end
 end

--- a/test/models/rss_feed_test.rb
+++ b/test/models/rss_feed_test.rb
@@ -17,7 +17,7 @@ class RssFeedTest < ActiveSupport::TestCase
       assert_equal items.length, 2
 
       assert_equal items[0], [
-        "<h1>Yahoo News - Latest News  Headlines</h1>",
+        "<h1>Yahoo News - Latest News &amp; Headlines</h1>",
         "<h2>Item 1 Title</h2>",
         "<h2>Item 2 Title</h2>",
         "<h2>Item 3 Title</h2>",
@@ -25,7 +25,7 @@ class RssFeedTest < ActiveSupport::TestCase
         "<h2>Item 5 Title</h2>" ].join()
 
         assert_equal items[1], [
-          "<h1>Yahoo News - Latest News  Headlines</h1>",
+          "<h1>Yahoo News - Latest News &amp; Headlines</h1>",
           "<h2>Item 6 Title</h2>",
           "<h2>Item 7 Title</h2>",
           "<h2>Item 8 Title</h2>",

--- a/test/support/basic_rss_feed.xml
+++ b/test/support/basic_rss_feed.xml
@@ -17,43 +17,43 @@
 			<link>https://www.yahoo.com/news.html</link>
 			<pubDate>2024-09-17T13:08:33Z</pubDate>
 			<source url="https://www.reuters.com/">Reuters</source>
-            <description>Description for Item 1</description>
+			<description>Description for Item 1</description>
 		</item>
-        <item>
+		<item>
 			<title>Item 2 Title</title>
-                <description>Description for Item 2</description>
+			<description>Description for Item 2</description>
 		</item>
-        <item>
+		<item>
 			<title>Item 3 Title</title>
-                <description>Description for Item 3</description>
+			<description>Description for Item 3</description>
 		</item>
-        <item>
-            <title>Item 4 Title</title>
-                <description>Description for Item 4</description>
-        </item>
-        <item>
-            <title>Item 5 Title</title>
-                <description>Description for Item 5</description>
-        </item>
-        <item>
-            <title>Item 6 Title</title>
-                <description>Description for Item 6</description>
-        </item>
-        <item>
-            <title>Item 7 Title</title>
-                <description>Description for Item 7</description>
-        </item>
-        <item>
-            <title>Item 8 Title</title>
-                <description>Description for Item 8</description>
-        </item>
-        <item>
-            <title>Item 9 Title</title>
-                <description>Description for Item 9</description>
-        </item>
-        <item>
-            <title>Item 10 Title</title>
-                <description>Description for Item 10</description>
-        </item>
-    </channel>
+		<item>
+			<title>Item 4 Title</title>
+			<description>Description for Item 4</description>
+		</item>
+		<item>
+			<title>Item 5 Title</title>
+			<description>Description for Item 5</description>
+		</item>
+		<item>
+			<title>Item 6 Title</title>
+			<description>Description for Item 6</description>
+		</item>
+		<item>
+			<title>Item 7 Title</title>
+			<description>Description for Item 7</description>
+		</item>
+		<item>
+			<title>Item 8 Title</title>
+			<description>Description for Item 8</description>
+		</item>
+		<item>
+			<title>Item 9 Title</title>
+			<description>Description for Item 9</description>
+		</item>
+		<item>
+			<title>Item 10 Title</title>
+			<description>Description for Item 10</description>
+		</item>
+	</channel>
 </rss>

--- a/test/support/basic_rss_feed.xml
+++ b/test/support/basic_rss_feed.xml
@@ -17,33 +17,43 @@
 			<link>https://www.yahoo.com/news.html</link>
 			<pubDate>2024-09-17T13:08:33Z</pubDate>
 			<source url="https://www.reuters.com/">Reuters</source>
+            <description>Description for Item 1</description>
 		</item>
         <item>
 			<title>Item 2 Title</title>
+                <description>Description for Item 2</description>
 		</item>
         <item>
 			<title>Item 3 Title</title>
+                <description>Description for Item 3</description>
 		</item>
         <item>
             <title>Item 4 Title</title>
+                <description>Description for Item 4</description>
         </item>
         <item>
             <title>Item 5 Title</title>
+                <description>Description for Item 5</description>
         </item>
         <item>
             <title>Item 6 Title</title>
+                <description>Description for Item 6</description>
         </item>
         <item>
             <title>Item 7 Title</title>
+                <description>Description for Item 7</description>
         </item>
         <item>
             <title>Item 8 Title</title>
+                <description>Description for Item 8</description>
         </item>
         <item>
             <title>Item 9 Title</title>
+                <description>Description for Item 9</description>
         </item>
-                <item>
+        <item>
             <title>Item 10 Title</title>
+                <description>Description for Item 10</description>
         </item>
     </channel>
 </rss>

--- a/test/support/basic_rss_feed.xml
+++ b/test/support/basic_rss_feed.xml
@@ -20,8 +20,8 @@
 			<description>Description for Item 1</description>
 		</item>
 		<item>
-			<title>Item 2 Title</title>
-			<description>Description for Item 2</description>
+			<title>Item 2 Title &amp; is fancy</title>
+			<description>Description for Item 2 &amp; too!</description>
 		</item>
 		<item>
 			<title>Item 3 Title</title>

--- a/test/support/basic_rss_feed.xml
+++ b/test/support/basic_rss_feed.xml
@@ -1,14 +1,14 @@
 <rss
 	xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
 	<channel>
-		<title>Yahoo News - Latest News & Headlines</title>
+		<title>Yahoo News - Latest News &amp; Headlines</title>
 		<link>https://www.yahoo.com/news</link>
 		<description>The latest news and headlines from Yahoo! News. Get breaking news stories and in-depth coverage with videos and photos.</description>
 		<language>en-US</language>
 		<pubDate>Tue, 17 Sep 2024 22:45:28 -0400</pubDate>
 		<ttl>5</ttl>
 		<image>
-			<title>Yahoo News - Latest News & Headlines</title>
+			<title>Yahoo News - Latest News &amp; Headlines</title>
 			<link>https://www.yahoo.com/news</link>
 			<url>http://l.yimg.com/rz/d/yahoo_news_en-US_s_f_p_168x21_news.png</url>
 		</image>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Display Type" option when creating or editing an RSS feed to choose “Headlines” or “Details”.
  * New RSS feeds default to “Headlines”.
  * “Headlines” groups items into compact headline lists; “Details” shows each item with title and description.
  * Item processing now supports richer content (title + description) for flexible rendering.

* **Tests**
  * Updated and added tests and fixtures to cover both display modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->