### PR TITLE
Revert "Bump puma from 6.6.1 to 7.0.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (7.0.0)
+    puma (6.6.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)


### PR DESCRIPTION
Reverts bamnet/concerto-fresh#405 until https://github.com/rails/solid_queue/issues/633 is fixed.