### PR TITLE
Each screen is managed by a group

### DIFF
--- a/app/controllers/screens_controller.rb
+++ b/app/controllers/screens_controller.rb
@@ -1,5 +1,5 @@
 class ScreensController < ApplicationController
-  before_action :set_templates, only: %i[ new edit ]
+  before_action :set_form_options, only: %i[ new edit ]
   before_action :set_screen, only: %i[ show edit update destroy ]
 
   # GET /screens or /screens.json
@@ -65,12 +65,14 @@ class ScreensController < ApplicationController
       @screen = Screen.find(params[:id])
     end
 
-    def set_templates
+    # Sets options for form selects.
+    def set_form_options
       @templates = Template.all.with_attached_image
+      @groups = Group.all
     end
 
     # Only allow a list of trusted parameters through.
     def screen_params
-      params.require(:screen).permit(:name, :template_id)
+      params.require(:screen).permit(:name, :template_id, :group_id)
     end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,6 +2,9 @@ class Group < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :users, through: :memberships
 
+  # Models that groups own or manage.
+  has_many :screens, dependent: :destroy
+
   validates :name, presence: true, uniqueness: true
 
   # Prevent deletion of system groups

--- a/app/models/screen.rb
+++ b/app/models/screen.rb
@@ -1,5 +1,6 @@
 class Screen < ApplicationRecord
   belongs_to :template
+  belongs_to :group
 
   has_many :subscriptions, dependent: :destroy
 end

--- a/app/views/screens/_form.html.erb
+++ b/app/views/screens/_form.html.erb
@@ -87,6 +87,15 @@
           <p class="text-xs text-gray-500 mt-3">Choose the layout template for this screen</p>
         </div>
 
+        <!-- Group Selection -->
+        <div>
+          <%= form.label :group_id, "Group", class: "block text-sm font-medium text-gray-700 mb-2" %>
+          <%= form.collection_select :group_id, @groups, :id, :name,
+              { prompt: "Select a group" },
+              { class: "block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm" } %>
+          <p class="text-xs text-gray-500 mt-1">Choose which group manages this screen</p>
+        </div>
+
       </div>
     </div>
 

--- a/app/views/screens/show.html.erb
+++ b/app/views/screens/show.html.erb
@@ -100,10 +100,16 @@
         <h2 class="text-lg font-semibold text-gray-900">Screen Information</h2>
       </div>
       <div class="p-4">
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
           <div>
             <dt class="text-sm font-medium text-gray-500">Screen Name</dt>
             <dd class="mt-1 text-sm text-gray-900"><%= @screen.name %></dd>
+          </div>
+          <div>
+            <dt class="text-sm font-medium text-gray-500">Group</dt>
+            <dd class="mt-1 text-sm text-gray-900">
+              <%= link_to @screen.group.name, @screen.group, class: "text-blue-600 hover:text-blue-800" %>
+            </dd>
           </div>
           <div>
             <dt class="text-sm font-medium text-gray-500">Template</dt>

--- a/db/migrate/20250924171155_add_group_to_screen.rb
+++ b/db/migrate/20250924171155_add_group_to_screen.rb
@@ -1,0 +1,5 @@
+class AddGroupToScreen < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :screens, :group, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_24_041842) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_171155) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -106,6 +106,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_24_041842) do
     t.integer "template_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "group_id", null: false
+    t.index ["group_id"], name: "index_screens_on_group_id"
     t.index ["template_id"], name: "index_screens_on_template_id"
   end
 
@@ -169,6 +171,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_24_041842) do
   add_foreign_key "memberships", "users"
   add_foreign_key "positions", "fields"
   add_foreign_key "positions", "templates"
+  add_foreign_key "screens", "groups"
   add_foreign_key "screens", "templates"
   add_foreign_key "submissions", "contents"
   add_foreign_key "submissions", "feeds"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,6 +67,8 @@ Graphic.transaction do
   end
 end
 
+demo_screen_group = Group.find_or_create_by!(name: "Demo Screen Owners", description: "Managers of the Demo Screen.")
+
 Field.transaction do
     main_field = Field.find_or_create_by!(name: "Main", alt_names: [ "Graphics" ])
     sidebar_field = Field.find_or_create_by!(name: "Sidebar", alt_names: [ "Text" ])
@@ -84,7 +86,7 @@ Field.transaction do
             template.save!
         end
 
-        screen = Screen.find_or_create_by!(name: "Demo Screen", template: template)
+        screen = Screen.find_or_create_by!(name: "Demo Screen", template: template, group: demo_screen_group)
         if screen.subscriptions.empty?
             screen.subscriptions.new(feed: general_feed, field: main_field)
             screen.subscriptions.new(feed: general_feed, field: ticker_field)

--- a/test/controllers/screens_controller_test.rb
+++ b/test/controllers/screens_controller_test.rb
@@ -17,7 +17,7 @@ class ScreensControllerTest < ActionDispatch::IntegrationTest
 
   test "should create screen" do
     assert_difference("Screen.count") do
-      post screens_url, params: { screen: { name: @screen.name, template_id: @screen.template_id } }
+      post screens_url, params: { screen: { name: @screen.name, template_id: @screen.template_id, group_id: @screen.group_id } }
     end
 
     assert_redirected_to screen_url(Screen.last)
@@ -34,7 +34,7 @@ class ScreensControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update screen" do
-    patch screen_url(@screen), params: { screen: { name: @screen.name, template_id: @screen.template_id } }
+    patch screen_url(@screen), params: { screen: { name: @screen.name, template_id: @screen.template_id, group_id: @screen.group_id } }
     assert_redirected_to screen_url(@screen)
   end
 

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -11,3 +11,11 @@ content_creators:
 moderators:
   name: Moderators
   description: Group for content moderators
+
+screen_one_owners:
+  name: Screen One Owners
+  description: Group owning Screen 1
+
+screen_two_owners:
+  name: Screen Two Owners
+  description: Group owning Screen 2

--- a/test/fixtures/screens.yml
+++ b/test/fixtures/screens.yml
@@ -3,11 +3,14 @@
 one:
   name: Screen 1
   template: two
+  group: content_creators
 
 two:
   name: Screen 2
   template: two
+  group: screen_one_owners
 
 e2e:
   name: System Test Screen
   template: two
+  group: screen_two_owners

--- a/test/system/screens_test.rb
+++ b/test/system/screens_test.rb
@@ -15,6 +15,7 @@ class ScreensTest < ApplicationSystemTestCase
     click_on "New Screen"
 
     fill_in "Name", with: @screen.name
+    select @screen.group.name, from: "Group"
     choose @screen.template.name, allow_label_click: true
     click_on "Save Screen"
 
@@ -27,6 +28,7 @@ class ScreensTest < ApplicationSystemTestCase
     click_on "Edit Screen", match: :first
 
     fill_in "Name", with: @screen.name
+    select @screen.group.name, from: "Group"
     choose @screen.template.name, allow_label_click: true
     click_on "Save Screen"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assign screens to a group via a new Group dropdown on create/edit.
  * Screen details now display the owning Group with a link; layout updated to accommodate the new field.
  * Creating a screen now requires selecting a group.

* **Chores**
  * Demo data enhanced with a sample group, richer template (including ticker/time), and additional feeds to improve the out‑of‑the‑box experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->