### PR TITLE
Add support for YouTube Shorts URLs

### DIFF
--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -22,7 +22,7 @@ class Video < Content
   def video_id
     if url.present?
       if video_source == "youtube"
-        match = url.match(/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/i)
+        match = url.match(/(?:youtube\.com\/(?:shorts\/|[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/i)
         match[1] if match
       elsif video_source == "vimeo"
         match = url.match(/vimeo\.com\/(\d+)/)

--- a/test/fixtures/videos.yml
+++ b/test/fixtures/videos.yml
@@ -9,6 +9,15 @@ video_youtube:
   config: {'url': 'https://www.youtube.com/watch?v=eT4OAYjzV-s'}
   user: admin
 
+video_youtube_short:
+  type: Video
+  name: Sample YouTube Short
+  duration: 30
+  start_time: 2024-12-24 03:10:59
+  end_time: 2024-12-24 03:10:59
+  config: {'url': 'https://www.youtube.com/shorts/JnKnz3QaYhA'}
+  user: admin
+
 video_two:
   type: Video
   name: MyString

--- a/test/models/video_test.rb
+++ b/test/models/video_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class VideoTest < ActiveSupport::TestCase
   setup do
     @youtube_video = videos(:video_youtube)
+    @youtube_short = videos(:video_youtube_short)
     @vimeo_video = videos(:video_vimeo) # Assuming a fixture for Vimeo videos exists
     @tiktok_video = videos(:video_tiktok)
   end
@@ -20,6 +21,14 @@ class VideoTest < ActiveSupport::TestCase
 
   test "extracts video id from youtube url" do
     assert_equal "eT4OAYjzV-s", @youtube_video.video_id
+  end
+
+  test "extracts video id from youtube shorts url" do
+    assert_equal "JnKnz3QaYhA", @youtube_short.video_id
+  end
+
+  test "youtube shorts have correct video source" do
+    assert_equal "youtube", @youtube_short.video_source
   end
 
   test "extracts video id from vimeo url" do


### PR DESCRIPTION
Fixes #494

This PR adds support for YouTube Shorts URLs like `https://www.youtube.com/shorts/JnKnz3QaYhA`.

### Changes
- Updated regex pattern in `Video#video_id` to recognize `/shorts/` path
- Added test fixture for YouTube Shorts URL
- Added test cases to verify video ID extraction and source detection

YouTube Shorts use the same video ID format and API as regular YouTube videos, so this is a simple pattern update.

----

Generated with [Claude Code](https://claude.ai/code)