### PR TITLE
Hide field border in production mode

### DIFF
--- a/app/frontend/components/ConcertoField.vue
+++ b/app/frontend/components/ConcertoField.vue
@@ -12,6 +12,9 @@ const defaultDuration = 10;
 // This is helpful when debugging when you need to "freeze" the frontend.
 const disableTimer = false;
 
+// Show debug border only in development mode
+const isDevelopment = import.meta.env.DEV;
+
 const contentTypeMap = new Map([
   ["Graphic", ConcertoGraphic],
   ["RichText", ConcertoRichText],
@@ -98,6 +101,7 @@ onMounted(() => {
 <template>
   <div
     class="field"
+    :class="{ 'dev-border': isDevelopment }"
     :style="fieldStyle"
   >
     <Transition>
@@ -116,6 +120,9 @@ onMounted(() => {
 <style scoped>
   .field {
     position: absolute;
+  }
+
+  .dev-border {
     border: 1px dashed yellow;
   }
 


### PR DESCRIPTION
## Summary

Fixes #552 by conditionally showing the yellow dashed debug border on Field components only in development mode.

## Changes

- Added `isDevelopment` constant using `import.meta.env.DEV` in `ConcertoField.vue`
- Created `.dev-border` CSS class for the debug border styling
- Applied conditional class binding to show border only in development
- Border is now hidden in production builds for cleaner presentation

## Testing

- All frontend tests pass (27/27)
- All Rails tests pass (573/573)
- ESLint and RuboCop both pass with no issues
- Verified that the border styling only applies when `import.meta.env.DEV` is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)