### PR TITLE
Enable multi-architecture Docker builds for ARM64 support

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -76,7 +76,9 @@ asset_path: /rails/public/assets
 
 # Configure the image builder.
 builder:
-  arch: amd64
+  arch:
+    - amd64
+    - arm64
 
   # Using GHA cache
   cache:


### PR DESCRIPTION
Update deploy.yml to build Docker images for both amd64 and arm64
architectures. This enables Concerto to run on ARM-based devices
like Raspberry Pi and NAS systems.

Changes:
- Add arm64 to the arch list in builder configuration
- Existing Docker Buildx setup in GitHub Actions already supports this

Fixes #591