### PR TITLE
Add PWA support and digital signage optimizations

### DIFF
--- a/app/frontend/components/ConcertoScreen.vue
+++ b/app/frontend/components/ConcertoScreen.vue
@@ -2,6 +2,9 @@
 import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
 import ConcertoField from './ConcertoField.vue'
 import { useConfigVersion } from '../composables/useConfigVersion.js'
+import { useWakeLock } from '../composables/useWakeLock.js'
+import { useNetworkStatus } from '../composables/useNetworkStatus.js'
+import { fetchWithTimeout, TIMEOUTS } from '../utils/fetchWithTimeout.js'
 
 // Retry configuration
 const INITIAL_RETRY_DELAY_MS = 1000;
@@ -19,6 +22,22 @@ let loadConfigRetryTimer = null;
 // Track config version to detect changes
 const { check: checkConfigVersion } = useConfigVersion('Screen');
 
+// Prevent screen from sleeping on digital signage displays
+useWakeLock();
+
+// Monitor network connectivity and trigger refresh when connection is restored
+const { isOnline } = useNetworkStatus({
+  onOnline: () => {
+    console.log('[Screen] Network restored, refreshing configuration');
+    // Clear any pending retry and refresh immediately
+    clearTimeout(loadConfigRetryTimer);
+    loadConfig(0);
+  },
+  onOffline: () => {
+    console.log('[Screen] Network lost, will use cached content');
+  }
+});
+
 const backgroundImageStyle = computed(() => {
   return backgroundImage.value ? `url(${backgroundImage.value})` : 'none';
 });
@@ -27,8 +46,15 @@ async function loadConfig(retryCount = 0) {
   const maxRetries = 3;
   const retryDelay = Math.min(INITIAL_RETRY_DELAY_MS * Math.pow(2, retryCount), MAX_RETRY_DELAY_MS);
 
+  // Skip fetch attempts if we know we're offline (service worker will handle cached responses)
+  if (!isOnline.value && retryCount > 0) {
+    console.debug('[Screen] Offline, delaying retry');
+    loadConfigRetryTimer = setTimeout(() => loadConfig(retryCount), LONG_RETRY_DELAY_MS);
+    return;
+  }
+
   try {
-    const resp = await fetch(props.apiUrl);
+    const resp = await fetchWithTimeout(props.apiUrl, { timeout: TIMEOUTS.CONFIG });
 
     if (!resp.ok) {
       throw new Error(`HTTP error! status: ${resp.status}`);
@@ -74,6 +100,7 @@ onBeforeUnmount(() => {
       :key="position.id"
       :api-url="position.content_uri"
       :field-style="position.style"
+      :is-online="isOnline"
       :style="{
         top: (100 * position.top).toFixed(2) + '%',
         left: (100 * position.left).toFixed(2) + '%',

--- a/app/frontend/composables/useNetworkStatus.js
+++ b/app/frontend/composables/useNetworkStatus.js
@@ -1,0 +1,55 @@
+import { ref, readonly, onMounted, onBeforeUnmount } from 'vue';
+
+/**
+ * Composable for monitoring network connectivity status.
+ * Tracks online/offline state and provides callbacks for status changes.
+ *
+ * @param {Object} options - Configuration options
+ * @param {Function} options.onOnline - Callback when network is restored
+ * @param {Function} options.onOffline - Callback when network is lost
+ * @returns {Object} Object with isOnline ref and wasOffline flag
+ */
+export function useNetworkStatus(options = {}) {
+  const { onOnline, onOffline } = options;
+
+  const isOnline = ref(navigator.onLine);
+  const wasOffline = ref(false);
+
+  function handleOnline() {
+    console.log('[NetworkStatus] Network connection restored');
+    isOnline.value = true;
+
+    if (wasOffline.value && onOnline) {
+      console.log('[NetworkStatus] Triggering recovery callback');
+      onOnline();
+    }
+  }
+
+  function handleOffline() {
+    console.log('[NetworkStatus] Network connection lost');
+    isOnline.value = false;
+    wasOffline.value = true;
+
+    if (onOffline) {
+      onOffline();
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    // Log initial state
+    console.log('[NetworkStatus] Initial state:', isOnline.value ? 'online' : 'offline');
+  });
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('online', handleOnline);
+    window.removeEventListener('offline', handleOffline);
+  });
+
+  return {
+    isOnline: readonly(isOnline),
+    wasOffline: readonly(wasOffline)
+  };
+}

--- a/app/frontend/composables/useWakeLock.js
+++ b/app/frontend/composables/useWakeLock.js
@@ -1,0 +1,102 @@
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+/**
+ * Composable for managing the Screen Wake Lock API.
+ * Prevents the screen from dimming or locking on digital signage displays.
+ *
+ * The wake lock is automatically requested on mount and released on unmount.
+ * It also handles visibility changes (re-acquires lock when page becomes visible).
+ *
+ * @returns {Object} Object with isSupported, isActive, and error refs
+ */
+export function useWakeLock() {
+  const isSupported = ref('wakeLock' in navigator);
+  const isActive = ref(false);
+  const error = ref(null);
+
+  let wakeLock = null;
+
+  /**
+   * Request a screen wake lock.
+   * Will silently fail if not supported or already active.
+   */
+  async function request() {
+    if (!isSupported.value) {
+      console.log('[WakeLock] API not supported in this browser');
+      return;
+    }
+
+    if (wakeLock !== null) {
+      // Already have an active wake lock
+      return;
+    }
+
+    try {
+      wakeLock = await navigator.wakeLock.request('screen');
+      isActive.value = true;
+      error.value = null;
+
+      console.log('[WakeLock] Screen wake lock acquired');
+
+      // Listen for the wake lock being released (e.g., by the system)
+      wakeLock.addEventListener('release', () => {
+        console.log('[WakeLock] Screen wake lock released');
+        isActive.value = false;
+        wakeLock = null;
+      });
+    } catch (err) {
+      error.value = err;
+      isActive.value = false;
+      console.error('[WakeLock] Failed to acquire wake lock:', err.message);
+    }
+  }
+
+  /**
+   * Release the current wake lock.
+   */
+  async function release() {
+    if (wakeLock !== null) {
+      try {
+        await wakeLock.release();
+        wakeLock = null;
+        isActive.value = false;
+        console.log('[WakeLock] Wake lock manually released');
+      } catch (err) {
+        console.error('[WakeLock] Error releasing wake lock:', err);
+      }
+    }
+  }
+
+  /**
+   * Handle visibility change events.
+   * Re-acquire wake lock when page becomes visible again.
+   */
+  function handleVisibilityChange() {
+    if (document.visibilityState === 'visible') {
+      console.log('[WakeLock] Page visible, re-acquiring wake lock');
+      request();
+    }
+  }
+
+  // Lifecycle hooks
+  onMounted(() => {
+    // Request wake lock immediately
+    request();
+
+    // Re-acquire wake lock when page becomes visible
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+  });
+
+  onBeforeUnmount(() => {
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    release();
+  });
+
+  return {
+    isSupported,
+    isActive,
+    error,
+    request,
+    release
+  };
+}

--- a/app/frontend/entrypoints/player.js
+++ b/app/frontend/entrypoints/player.js
@@ -1,6 +1,19 @@
 import { createApp } from 'vue'
 import App from '../components/ConcertoScreen.vue'
 
+// Register service worker for offline support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js')
+      .then((registration) => {
+        console.log('[Player] ServiceWorker registered:', registration.scope);
+      })
+      .catch((error) => {
+        console.error('[Player] ServiceWorker registration failed:', error);
+      });
+  });
+}
+
 const div = document.getElementById('screen');
 const apiUrl = div.dataset.apiUrl;
 

--- a/app/frontend/utils/fetchWithTimeout.js
+++ b/app/frontend/utils/fetchWithTimeout.js
@@ -1,0 +1,41 @@
+/**
+ * Fetch with timeout support using AbortController.
+ * Prevents fetch calls from hanging indefinitely on flaky networks.
+ *
+ * @param {string} url - The URL to fetch
+ * @param {Object} options - Fetch options
+ * @param {number} options.timeout - Timeout in milliseconds (default: 30000)
+ * @param {Object} options.fetchOptions - Additional fetch options
+ * @returns {Promise<Response>} The fetch response
+ * @throws {Error} Throws if request times out or fails
+ */
+export async function fetchWithTimeout(url, { timeout = 30000, ...fetchOptions } = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeout);
+
+  try {
+    const response = await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal
+    });
+    return response;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error(`Request timeout after ${timeout}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Default timeout values for different request types.
+ */
+export const TIMEOUTS = {
+  API: 30000,      // 30 seconds for API requests
+  MEDIA: 60000,    // 60 seconds for media (images, videos)
+  CONFIG: 15000    // 15 seconds for configuration requests
+};

--- a/app/views/frontend/player/show.html.erb
+++ b/app/views/frontend/player/show.html.erb
@@ -3,8 +3,13 @@
   <head>
     <title>Concerto Player</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="apple-touch-icon" href="/icon.png">
     <%= vite_client_tag %>
     <%= vite_javascript_tag 'player' %>
     <style>

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,6 @@
 {
-  "name": "Concerto",
+  "name": "Concerto Player",
+  "short_name": "Concerto",
   "icons": [
     {
       "src": "/icon.png",
@@ -14,9 +15,10 @@
     }
   ],
   "start_url": "/",
-  "display": "standalone",
+  "display": "fullscreen",
+  "orientation": "landscape",
   "scope": "/",
-  "description": "Concerto.",
-  "theme_color": "red",
-  "background_color": "red"
+  "description": "Digital signage player for Concerto.",
+  "theme_color": "#007BFF",
+  "background_color": "#000000"
 }

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -1,26 +1,159 @@
-// Add a service worker for processing Web Push notifications:
-//
-// self.addEventListener("push", async (event) => {
-//   const { title, options } = await event.data.json()
-//   event.waitUntil(self.registration.showNotification(title, options))
-// })
-//
-// self.addEventListener("notificationclick", function(event) {
-//   event.notification.close()
-//   event.waitUntil(
-//     clients.matchAll({ type: "window" }).then((clientList) => {
-//       for (let i = 0; i < clientList.length; i++) {
-//         let client = clientList[i]
-//         let clientPath = (new URL(client.url)).pathname
-//
-//         if (clientPath == event.notification.data.path && "focus" in client) {
-//           return client.focus()
-//         }
-//       }
-//
-//       if (clients.openWindow) {
-//         return clients.openWindow(event.notification.data.path)
-//       }
-//     })
-//   )
-// })
+// Concerto Player Service Worker
+// Provides offline resilience for digital signage displays
+
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `concerto-static-${CACHE_VERSION}`;
+const CONTENT_CACHE = `concerto-content-${CACHE_VERSION}`;
+
+// Static assets to cache on install (app shell)
+const STATIC_ASSETS = [
+  '/icon.png',
+  '/manifest.json'
+];
+
+// Install event - cache static assets
+self.addEventListener('install', (event) => {
+  console.log('[ServiceWorker] Installing...');
+  event.waitUntil(
+    caches.open(STATIC_CACHE)
+      .then((cache) => {
+        console.log('[ServiceWorker] Caching static assets');
+        return cache.addAll(STATIC_ASSETS);
+      })
+      .then(() => self.skipWaiting())
+  );
+});
+
+// Activate event - clean up old caches
+self.addEventListener('activate', (event) => {
+  console.log('[ServiceWorker] Activating...');
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames
+          .filter((name) => name.startsWith('concerto-') && name !== STATIC_CACHE && name !== CONTENT_CACHE)
+          .map((name) => {
+            console.log('[ServiceWorker] Deleting old cache:', name);
+            return caches.delete(name);
+          })
+      );
+    }).then(() => self.clients.claim())
+  );
+});
+
+// Fetch event - handle requests with appropriate caching strategy
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  // API requests (JSON) - network first, cache fallback
+  if (request.headers.get('Accept')?.includes('application/json') ||
+      url.pathname.includes('/frontend/')) {
+    event.respondWith(networkFirstWithCache(request, CONTENT_CACHE));
+    return;
+  }
+
+  // Image/media requests - cache first, network fallback
+  if (request.destination === 'image' ||
+      request.destination === 'video' ||
+      url.pathname.match(/\.(png|jpg|jpeg|gif|webp|svg|mp4|webm)$/i)) {
+    event.respondWith(cacheFirstWithNetwork(request, CONTENT_CACHE));
+    return;
+  }
+
+  // Static assets - cache first
+  if (STATIC_ASSETS.some(asset => url.pathname.endsWith(asset))) {
+    event.respondWith(cacheFirstWithNetwork(request, STATIC_CACHE));
+    return;
+  }
+
+  // All other requests - network first
+  event.respondWith(networkFirstWithCache(request, CONTENT_CACHE));
+});
+
+/**
+ * Network-first strategy with cache fallback.
+ * Best for API requests where fresh data is preferred but cached data is acceptable offline.
+ */
+async function networkFirstWithCache(request, cacheName) {
+  try {
+    const networkResponse = await fetch(request);
+
+    // Cache successful responses
+    if (networkResponse.ok) {
+      const cache = await caches.open(cacheName);
+      // Clone the response since it can only be consumed once
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    console.log('[ServiceWorker] Network failed, trying cache:', request.url);
+    const cachedResponse = await caches.match(request);
+
+    if (cachedResponse) {
+      console.log('[ServiceWorker] Serving from cache:', request.url);
+      return cachedResponse;
+    }
+
+    // No cache available - return a basic error response for JSON requests
+    if (request.headers.get('Accept')?.includes('application/json')) {
+      return new Response(JSON.stringify({ error: 'offline', cached: false }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Cache-first strategy with network fallback.
+ * Best for images and media that don't change frequently.
+ */
+async function cacheFirstWithNetwork(request, cacheName) {
+  const cachedResponse = await caches.match(request);
+
+  if (cachedResponse) {
+    // Return cached response immediately
+    // Optionally refresh cache in background (stale-while-revalidate)
+    refreshCache(request, cacheName);
+    return cachedResponse;
+  }
+
+  // Not in cache - fetch from network and cache
+  try {
+    const networkResponse = await fetch(request);
+
+    if (networkResponse.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, networkResponse.clone());
+    }
+
+    return networkResponse;
+  } catch (error) {
+    console.log('[ServiceWorker] Network failed and no cache for:', request.url);
+    throw error;
+  }
+}
+
+/**
+ * Background cache refresh for stale-while-revalidate pattern.
+ */
+async function refreshCache(request, cacheName) {
+  try {
+    const networkResponse = await fetch(request);
+    if (networkResponse.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, networkResponse);
+    }
+  } catch (error) {
+    // Silently fail - we already have a cached version
+  }
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,9 +43,9 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  # Render dynamic PWA files from app/views/pwa/*
+  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
   root "contents#index"


### PR DESCRIPTION
## Summary

- Enable PWA manifest and service worker routes for installable app support
- Add Screen Wake Lock API to prevent displays from sleeping in kiosk mode
- Add network status detection with automatic content refresh on reconnect
- Add fetch timeouts (via AbortController) to prevent hanging requests

## Changes

### PWA Infrastructure
- Enable manifest and service worker routes in `config/routes.rb`
- Update `manifest.json.erb` with fullscreen display mode, landscape orientation, and proper branding colors
- Implement service worker with caching strategies:
  - Network-first for API requests (with cache fallback for offline)
  - Cache-first for images/media (with stale-while-revalidate)

### New Composables
- `useWakeLock.js` - Prevents screen from sleeping, handles visibility changes
- `useNetworkStatus.js` - Detects online/offline status, triggers callbacks on change

### New Utilities
- `fetchWithTimeout.js` - Wraps fetch with AbortController for configurable timeouts

### Component Updates
- `ConcertoScreen.vue` - Integrates wake lock, network status, and fetch timeouts
- `ConcertoField.vue` - Adds fetch timeouts and network-aware retry logic
- `player.js` - Registers service worker on load
- `show.html.erb` - Adds PWA meta tags and manifest link

## Test plan

- [ ] Verify player can be installed as PWA on Chrome/Edge
- [ ] Test wake lock keeps screen on (check `navigator.wakeLock` in devtools)
- [ ] Test offline mode: disconnect network, verify cached content still displays
- [ ] Test network recovery: reconnect network, verify content refreshes automatically
- [ ] Test fetch timeout: simulate slow network, verify requests don't hang forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)