### PR TITLE
Fix sporadic CI failures due to empty Vite manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,13 @@ jobs:
         with:
           cache: 'yarn'
 
+      - name: Install Node packages
+        run: yarn install
+
       - name: Build assets (esp frontend player)
         run: bin/rake assets:precompile
+        env:
+          RAILS_ENV: test
 
       - name: Run tests
         env:
@@ -156,8 +161,13 @@ jobs:
         with:
           cache: 'yarn'
 
+      - name: Install Node packages
+        run: yarn install
+
       - name: Build assets (esp frontend player)
         run: bin/rake assets:precompile
+        env:
+          RAILS_ENV: test
 
       - name: Run System Tests
         env:


### PR DESCRIPTION
## Summary
- Fixes intermittent CI test failures with "Vite Ruby can't find entrypoints/player.js in the manifests"
- Adds `yarn install` step before asset builds in test and system-test jobs
- Sets `RAILS_ENV=test` on `assets:precompile` so Vite builds to the correct directory (`public/vite-test`)

## Root Cause
The `assets:precompile` step was running without `RAILS_ENV=test`, causing Vite to build assets to `public/vite` instead of `public/vite-test`. When tests ran with `RAILS_ENV=test`, they looked in the wrong directory. With `autoBuild: true`, parallel test workers then tried to build simultaneously, causing race conditions that corrupted the manifest.

## Test plan
- [ ] Verify CI passes consistently on this PR
- [ ] Re-run failed CI jobs from recent PRs to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)