### PR TITLE
Hide Manage Subscriptions button for users without access

### DIFF
--- a/app/views/screens/show.html.erb
+++ b/app/views/screens/show.html.erb
@@ -7,12 +7,14 @@
       <div>
         <h1 class="text-2xl font-bold text-gray-900"><%= @screen.name %></h1>
         <p class="text-sm text-gray-600 mt-1">Manage screen configuration and feed subscriptions</p>
-      </div><div class="flex space-x-3">
-  <% if policy(@screen).edit? %>
-    <%= link_to "Manage Subscriptions", screen_subscriptions_path(@screen), class: "btn-primary" %>
-    <%= link_to "Edit Screen", edit_screen_path(@screen), class: "btn-secondary" %>
-  <% end %>
-</div>
+      </div>
+
+      <div class="flex space-x-3">
+        <% if policy(@screen).edit? %>
+          <%= link_to "Manage Subscriptions", screen_subscriptions_path(@screen), class: "btn-primary" %>
+          <%= link_to "Edit Screen", edit_screen_path(@screen), class: "btn-secondary" %>
+        <% end %>
+      </div>
     </div>
   </div>
 
@@ -27,7 +29,7 @@
         <div class="p-4">
           <% if @screen.template.image.attached? %>
             <div class="bg-gray-50 rounded-lg p-4">
-              <%= render partial: "templates/preview", locals: {template: @screen.template} %>
+              <%= render partial: "templates/preview", locals: { template: @screen.template } %>
             </div>
           <% else %>
             <div class="bg-gray-50 rounded-lg p-8 text-center">
@@ -55,17 +57,24 @@
               <h2 class="text-lg font-semibold text-gray-900">Feed Subscriptions</h2>
               <p class="text-sm text-gray-600 mt-1">Content sources for each position</p>
             </div>
-            <%= link_to "Manage All", screen_subscriptions_path(@screen), class: "inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+
+            <% if policy(@screen).edit? %>
+              <%= link_to "Manage All", screen_subscriptions_path(@screen),
+                  class: "inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+            <% end %>
           </div>
         </div>
+
         <div class="p-4 space-y-4">
           <% @screen.template.positions.each do |position| %>
             <div class="border border-gray-200 rounded-lg p-3">
               <h3 class="text-sm font-semibold text-gray-900 mb-2">
                 <%= position.field.name %>
               </h3>
+
               <% field_config = @field_configs_by_field[position.field_id] %>
               <% subscriptions = @subscriptions_by_field[position.field_id] || [] %>
+
               <% if field_config || subscriptions.any? %>
                 <div class="space-y-2">
                   <!-- Pinned Content -->
@@ -74,9 +83,11 @@
                       <div class="flex items-center space-x-2">
                         <svg class="w-3 h-3 text-amber-600 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                           <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-                          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 002 0V6zm0 8a1 1 0 10-2 0 1 1 0 002 0z" clip-rule="evenodd"/>
+                          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 002 0V6zm0 8a1 1 0 10-2 0 1 1 0 001 1z" clip-rule="evenodd"/>
                         </svg>
-                        <span class="text-sm text-gray-900 font-medium"><%= link_to field_config.pinned_content.name, field_config.pinned_content %></span>
+                        <span class="text-sm text-gray-900 font-medium">
+                          <%= link_to field_config.pinned_content.name, field_config.pinned_content %>
+                        </span>
                         <span class="text-xs text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">Pinned</span>
                       </div>
                     </div>
@@ -99,8 +110,11 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
                   </svg>
                   <p class="text-xs text-gray-500">No feeds subscribed</p>
-                  <%= link_to "Add Feed", screen_subscriptions_path(@screen),
-                      class: "text-xs text-blue-600 hover:text-blue-800 font-medium" %>
+
+                  <% if policy(@screen).edit? %>
+                    <%= link_to "Add Feed", screen_subscriptions_path(@screen),
+                        class: "text-xs text-blue-600 hover:text-blue-800 font-medium" %>
+                  <% end %>
                 </div>
               <% end %>
             </div>
@@ -130,7 +144,9 @@
           </div>
           <div>
             <dt class="text-sm font-medium text-gray-500">Template</dt>
-            <dd class="mt-1 text-sm text-gray-900"><%= link_to @screen.template.name, @screen.template, class: "text-blue-600 hover:text-blue-800" %></dd>
+            <dd class="mt-1 text-sm text-gray-900">
+              <%= link_to @screen.template.name, @screen.template, class: "text-blue-600 hover:text-blue-800" %>
+            </dd>
           </div>
           <div>
             <dt class="text-sm font-medium text-gray-500">Total Subscriptions</dt>

--- a/app/views/screens/show.html.erb
+++ b/app/views/screens/show.html.erb
@@ -7,13 +7,12 @@
       <div>
         <h1 class="text-2xl font-bold text-gray-900"><%= @screen.name %></h1>
         <p class="text-sm text-gray-600 mt-1">Manage screen configuration and feed subscriptions</p>
-      </div>
-      <div class="flex space-x-3">
-        <%= link_to "Manage Subscriptions", screen_subscriptions_path(@screen), class: "btn-primary" %>
-        <% if policy(@screen).edit? %>
-          <%= link_to "Edit Screen", edit_screen_path(@screen), class: "btn-secondary" %>
-        <% end %>
-      </div>
+      </div><div class="flex space-x-3">
+  <% if policy(@screen).edit? %>
+    <%= link_to "Manage Subscriptions", screen_subscriptions_path(@screen), class: "btn-primary" %>
+    <%= link_to "Edit Screen", edit_screen_path(@screen), class: "btn-secondary" %>
+  <% end %>
+</div>
     </div>
   </div>
 


### PR DESCRIPTION
This PR hides the Manage Subscriptions button for users who do not have permission to edit or manage subscriptions on a screen.